### PR TITLE
Fixed cJSON related build errors

### DIFF
--- a/project/oxr_sharedApp/gcc/Makefile
+++ b/project/oxr_sharedApp/gcc/Makefile
@@ -33,6 +33,7 @@ SRCS += ../shared/src/new_common
 SRCS += ../shared/src/new_builtin_devices
 SRCS += ../shared/src/rgb2hsv
 
+SRCS += ../shared/src/httpserver/hass
 SRCS += ../shared/src/httpserver/new_http
 SRCS += ../shared/src/httpserver/http_tcp_server
 SRCS += ../shared/src/httpserver/http_fns
@@ -53,6 +54,8 @@ SRCS += ../shared/src/cmnds/cmd_tasmota
 SRCS += ../shared/src/cmnds/cmd_tcp
 SRCS += ../shared/src/cmnds/cmd_test
 SRCS += ../shared/src/cmnds/cmd_tokenizer
+
+SRCS += ../shared/src/cJSON/cJSON
 
 SRCS += ../shared/src/driver/drv_bl0942
 SRCS += ../shared/src/driver/drv_main

--- a/src/Makefile
+++ b/src/Makefile
@@ -52,7 +52,6 @@ SUBDIRS += driver/component \
 	audio/manager \
 	$(NET_SUBDIRS) \
 	$(AT_SUBDIRS) \
-	cjson \
 	util
 endif
 


### PR DESCRIPTION
This merge adjusts build file to skip building SDK cJSON. This is for https://github.com/openshwprojects/OpenBK7231T_App/pull/183.