### PR TITLE
Skip cjson from linked library list

### DIFF
--- a/project/project.mk
+++ b/project/project.mk
@@ -55,7 +55,7 @@ LIBRARIES += -lmqtt \
 	-lxrsys
 endif
 
-LIBRARIES += -lcjson -lfs -lconsole -lcomponent -lefpg -lpm -laudmgr -lpcm \
+LIBRARIES += -lfs -lconsole -lcomponent -lefpg -lpm -laudmgr -lpcm \
 	-lutil
 
 endif # __CONFIG_BOOTLOADER


### PR DESCRIPTION
Previously I had adjusted 
* `project/oxr_sharedApp/gcc/Makefile` to build the new files
* `src/Makefile` to not build cjson

But I failed to adjust `project/project.mk` which is where cjson library is being linked - `LIBRARIES += -lcjson -lfs -lconsole -lcomponent -lefpg -lpm -laudmgr -lpcm`. I have removed cjson now. Hopefully this should build failures.